### PR TITLE
WIP: Add support for quiet level

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: 'If set, check hidden files (those starting with ".") as well'
     required: false
     default: ''
+  quiet_level:
+    description: 'Bitmask that allows suppressing messages'
+    required: false
+    default: ''
   exclude_file:
     description: 'File with lines that should not be checked for spelling mistakes'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,6 +20,11 @@ if [ -n "${INPUT_CHECK_HIDDEN}" ]; then
     echo "Checking hidden"
     command_args="${command_args} --check-hidden"
 fi
+echo "Check quiet level? '${INPUT_QUIET_LEVEL}'"
+if [ -n "${INPUT_QUIET_LEVEL}" ]; then
+    echo "Checking quiet level"
+    command_args="${command_args} --quiet-level ${INPUT_QUIET_LEVEL}"
+fi
 echo "Exclude file '${INPUT_EXCLUDE_FILE}'"
 if [ "x${INPUT_EXCLUDE_FILE}" != "x" ]; then
     command_args="${command_args} --exclude-file ${INPUT_EXCLUDE_FILE}"

--- a/test/test.bats
+++ b/test/test.bats
@@ -20,6 +20,7 @@ function setup() {
     # Set default input values
     export INPUT_CHECK_FILENAMES=""
     export INPUT_CHECK_HIDDEN=""
+    export INPUT_QUIET_LEVEL=""
     export INPUT_EXCLUDE_FILE=""
     export INPUT_SKIP=""
     export INPUT_BUILTIN=""


### PR DESCRIPTION
On [`mne-python`](https://github.com/mne-tools/mne-python/pull/8514#issuecomment-727205557), we would like to have access to the `--quiet-level` parameter to suppress some messages.

This PR adds support for the quiet level.

It's still work in progress, I am not familiar with actions design and I need help to write useful tests.