### PR TITLE
Add support for reading codespell config from pyproject.toml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 codespell>=2.0.0
+tomli ; python_version < "3.11"


### PR DESCRIPTION
`codespell`'s latest [release](https://github.com/codespell-project/codespell/releases) adds support for reading its configuration from `pyproject.toml` if `tomli` or `tomllib` are present.  The latter is in the Standard Library of Python >= 3.11.