### PR TITLE
ENH: Enable use of pyproject.toml

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -23,9 +23,14 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v4
+        with:
+          python-version: 3.10
 
       - name: Install codespell via pip using ${{ matrix.codespell_pip_version }}
         run: pip3 --quiet --quiet install ${{ matrix.codespell_pip_version }}
+
+      - name: Check codespell
+        run: codespell --version
 
       - name: Install Bats
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -24,10 +24,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.10'
 
       - name: Install codespell via pip using ${{ matrix.codespell_pip_version }}
-        run: pip3 --quiet --quiet install ${{ matrix.codespell_pip_version }}
+        run: pip install ${{ matrix.codespell_pip_version }}
 
       - name: Check codespell
         run: codespell --version

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-codespell>=2.0.0
+codespell[toml]>=2.2.4


### PR DESCRIPTION
Eventually we should add the `--toml` option, but in the meantime this 1) avoids the problematic 2.2.3 release, and 2) enables implicit `pyproject.toml` option support.