### PR TITLE
feat: bump to use node20 runtime

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -64,7 +64,7 @@ jobs:
         check_filenames: true
         check_hidden: true
         # When using this Action in other repos, the --skip option below can be removed
-        skip: ./.git,./codespell-problem-matcher/test,./test,./README.md,./.github/workflows/testing.yml
+        skip: ./.git,./codespell-problem-matcher/test,./test,./README.md,./.github/workflows/testing.yml,./.pre-commit-config.yaml
     # Check our README (and this workflow) ignoring the two intentional typos
     - uses: ./
       with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.6
+    hooks:
+      - id: codespell
+        additional_dependencies:
+          - tomli

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,6 @@ repos:
     rev: v2.2.6
     hooks:
       - id: codespell
-        args: [--skip, "abandonned,ackward,bu"]
+        args: [--ignore-words-list, "abandonned,ackward,bu"]
         additional_dependencies:
           - tomli

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,5 +3,6 @@ repos:
     rev: v2.2.6
     hooks:
       - id: codespell
+        args: [--skip, "abandonned,ackward,bu"]
         additional_dependencies:
           - tomli

--- a/codespell-problem-matcher/action.yml
+++ b/codespell-problem-matcher/action.yml
@@ -2,7 +2,7 @@ name: 'codespell problem matcher'
 author: 'Peter Newman'
 description: 'Shows codespell errors as annotation (with file and code line) in GitHub Actions'
 runs:
-  using: 'node12'
+  using: 'node20'
   main: 'index.js'
 branding:
   icon: 'search'


### PR DESCRIPTION
**Description:**

Node12 was deleted from the runner recently. And Node 16 reaches the [end of life soon on 11 Sep 2023](https://nodejs.org/en/blog/announcements/nodejs16-eol). This PR updates the default runtime to `node20` (Node 20). ~I have also bumped the actions/checkout version to v4 for the same. (https://github.com/actions/runner/pull/2732)~

-----------------
A major version bump might be needed after the PRs merge.