### PR TITLE
Run as a non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,11 @@ COPY LICENSE \
         requirements.txt \
         /code/
 
-RUN pip install -r /code/requirements.txt
+RUN pip install -r /code/requirements.txt \
+    && addgroup -g 1000 codespell \
+    && adduser -u 1000 -G codespell -s /bin/sh -D codespell
+
+USER 1000
 
 ENTRYPOINT ["/code/entrypoint.sh"]
 CMD []


### PR DESCRIPTION
Running as a non-root user is a security best practice. Some environments require containers run as non-root users.

For the `USER` directive, a numeric uid is specified instead of the username because systems configured to disallow running images as root aren't able to run images that use user name string values for the `USER` because they can't validate that a named user isn't root. See https://github.com/kubernetes/kubernetes/pull/56503 for details.