### PR TITLE
Upgrade to Python 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine
+FROM python:3.13-alpine
 
 COPY LICENSE \
         README.md \


### PR DESCRIPTION
Python 3.8 is end of life

Python 3.13 is the current latest version.

See: https://devguide.python.org/versions/