### PR TITLE
docs: document the config input parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ with:
 
 ### Parameter: config
 
-Path to a `codespell` config file (for example `setup.cfg` or `.codespellrc`).
+Path to a `codespell` config file. The file uses INI format with a `[codespell]` section.
 
-This parameter is optional; by default `codespell` will use its own configuration discovery.
+This parameter is optional. By default `codespell` automatically reads configuration from `pyproject.toml`, `setup.cfg`, and `.codespellrc` in the working directory; use this parameter only to point at a config file in a non-standard location.
 
 ```yml
 uses: codespell-project/actions-codespell@v2
 with:
-  config: .codespellrc
+  config: path/to/codespell.cfg
 ```
 
 ### Parameter: skip

--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ with:
   exclude_file: src/foo
 ```
 
+### Parameter: config
+
+Path to a `codespell` config file (for example `setup.cfg` or `.codespellrc`).
+
+This parameter is optional; by default `codespell` will use its own configuration discovery.
+
+```yml
+uses: codespell-project/actions-codespell@v2
+with:
+  config: .codespellrc
+```
+
 ### Parameter: skip
 
 Comma-separated list of files to skip (it accepts globs as well).


### PR DESCRIPTION
## Summary

The action exposes a `config` input in `action.yml`, and `entrypoint.sh` maps it to codespell's `--config` flag. However, it was the only input missing from the README's parameter list.

This PR adds a `### Parameter: config` section, formatted consistently with the other documented parameters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)