### PR TITLE
Pin the base image to a digest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,10 @@ updates:
     directory: / # Check the repository's workflows under /.github/workflows/
     schedule:
       interval: daily
+
+  # Configure check for outdated base image digest in the Dockerfile.
+  # See: https://docs.docker.com/build/building/best-practices/#pin-base-image-versions
+  - package-ecosystem: docker
+    directory: / # Check the repository's Dockerfile at /Dockerfile
+    schedule:
+      interval: weekly

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-alpine
+FROM python:3.13-alpine@sha256:399babc8b49529dabfd9c922f2b5eea81d611e4512e3ed250d75bd2e7683f4b0
 
 COPY LICENSE \
         README.md \


### PR DESCRIPTION
python:3.13-alpine is a mutable tag that gets updated whenever upstream ships Alpine/Python patches, so a build today could pull different content than a build tomorrow with no change to this file. Pin to the digest instead.