### PR TITLE
Bump actions/checkout from 6 to 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Any warnings or errors will be annotated in the Pull Request.
 ## Usage
 
 ```yml
-- uses: actions/checkout@v6
+- uses: actions/checkout@v7
 - uses: codespell-project/actions-codespell@v2
 ```
 


### PR DESCRIPTION
Should we add dependency bot to fix it automatically in future (somehow)?